### PR TITLE
Change population_by_tourism_region indicator to percentage

### DIFF
--- a/frontend/constants/themes/general-insights.tsx
+++ b/frontend/constants/themes/general-insights.tsx
@@ -58,10 +58,12 @@ const theme: ThemeFrontendDefinition = {
           ...d,
           color: REGION_COLORS[d.region_slug],
         }));
+        const total = data.reduce((prev, { value }) => prev + value, 0);
+        const dataPercent = data.map((d) => ({ ...d, value: (100 * d.value) / total }));
 
         return {
           type: 'charts/pie',
-          data,
+          data: dataPercent,
           controls: [
             { type: 'select', side: 'right', name: 'year', options: getAvailableYearsOptions(rawData, false) },
           ],
@@ -70,10 +72,16 @@ const theme: ThemeFrontendDefinition = {
               nameKey: 'region',
               dataKey: 'value',
               label: function ({ value }) {
-                return Number(value).toLocaleString();
+                return `${Number(value).toFixed(1)}%`;
               },
             },
           ],
+          tooltip: {
+            ...defaultTooltip,
+            valueFormatter: (value) => {
+              return `${Number(value).toFixed(1)}% `;
+            },
+          },
         };
       },
     },


### PR DESCRIPTION
This PR changes the indicator population_by_tourism_region from total to percentage value

## Test instructions 

-  Go to [/themes/british-columbia/general-insights](https://tota-git-client-tm-1-change-population-to-pe-77e847-vizzuality1.vercel.app/themes/british-columbia/general-insights) widget 2 - 'Population'
- The pie chart should indicate the value in percentage, as well the tooltip 

<img width="1427" alt="Screenshot 2023-04-03 at 11 54 25" src="https://user-images.githubusercontent.com/48164343/229476232-0166afc5-a61f-42bb-9f04-5358a069f627.png">

## Task

https://vizzuality.atlassian.net/browse/TM-1