### PR TITLE
Merge airport data with Tourism Industry & Arrivals

### DIFF
--- a/frontend/constants/themes.ts
+++ b/frontend/constants/themes.ts
@@ -1,7 +1,7 @@
 import { ThemeFrontendDefinition, ThemeCategoryFrontendDefinition } from 'types';
 import generalInsights from './themes/general-insights';
 import tourismIndustryArrivals from './themes/tourism-industry-arrivals';
-import airportInformation from './themes/airport-information';
+// import airportInformation from './themes/airport-information';
 import accommodationInformation from './themes/accommodation-information';
 import tourismDevelopmentFounds from './themes/tourism-development-founds';
 import tourismEmployment from './themes/tourism-employment';
@@ -20,7 +20,7 @@ export const THEMES_CATEGORIES: ThemeCategoryFrontendDefinition[] = [
     children: [
       tourismIndustryArrivals,
       tourismEmployment,
-      airportInformation,
+      // airportInformation,
       accommodationInformation,
       tourismDevelopmentFounds,
       visitorSpending,
@@ -41,7 +41,7 @@ export const THEMES: ThemeFrontendDefinition[] = [
   generalInsights,
   tourismIndustryArrivals,
   tourismEmployment,
-  airportInformation,
+  // airportInformation,
   accommodationInformation,
   tourismDevelopmentFounds,
   visitorSpending,

--- a/frontend/hooks/widgets/index.ts
+++ b/frontend/hooks/widgets/index.ts
@@ -28,7 +28,11 @@ function mergeWithFrontendDefinitions(themeSlug: string, data: WidgetAPI[]): Wid
 export function useWidgets(themeSlug: string, selectedRegion?: Region) {
   const result = useQuery<WidgetAPI[], Error, Widget[]>(
     ['widgets', { themeSlug }],
-    () => TotaAPI.get(`widgets?filter[theme_slug]=${themeSlug}`),
+    () => {
+      const slug =
+        themeSlug === 'tourism_industry_arrivals' ? 'tourism_industry_arrivals,airport_information' : themeSlug;
+      return TotaAPI.get(`widgets?filter[theme_slug]=${slug}`);
+    },
     {
       keepPreviousData: true,
       staleTime: Infinity,


### PR DESCRIPTION
This PR adds passenger_volume indicator to tourism_industry_arrivals theme and removes airport_information theme

## Testing instructions

Go to [/themes/british-columbia/tourism-industry-arrivals](https://tota-git-client-featuretm-3-airport-informat-38fb24-vizzuality1.vercel.app/themes/british-columbia/tourism-industry-arrivals)

- The widget 2 should be 'Total passenger volume'
- The selector 'Business Investment Attraction' should NOT contain 'Airport Information' option;

## Task
https://vizzuality.atlassian.net/browse/TM-3