### PR TITLE
Fix get year function

### DIFF
--- a/frontend/utils/charts.ts
+++ b/frontend/utils/charts.ts
@@ -126,8 +126,9 @@ export const range = (start: number, end: number) => Array.from({ length: end - 
 
 export function getYear(str: string): string {
   if (!str) return str;
-
-  return new Date(str.replace(/Q\d/, '').replace(/W\d\d/, '')).getUTCFullYear().toString();
+  const quarterRegex = new RegExp(/-Q\d/);
+  const monthRegex = new RegExp(/-W\d\d/);
+  return new Date(str.replace(quarterRegex, '').replace(monthRegex, '')).getUTCFullYear().toString();
 }
 
 export function getYears(data: any[]): string[] {


### PR DESCRIPTION
This PR fixes a bug with selected year for chart visualisation 

The selected year was different from the year showing on chart:
<img width="770" alt="Screenshot 2023-04-11 at 11 59 54" src="https://user-images.githubusercontent.com/48164343/231501525-6abaf9d2-77f1-4789-8e16-ee52399c620f.png">

The bug was reported for "Accomodation Information" indicators, but I detected the error on other indicators, like [here](https://tourismimpactportal.com/themes/thompson-okanagan/tourism-industry-arrivals)
<img width="1295" alt="Screenshot 2023-04-12 at 17 15 07" src="https://user-images.githubusercontent.com/48164343/231503200-fb6387ed-60ee-4519-98ba-ee319fec900b.png">

## Testing instructions
Go to [Accomodation Information category](https://tourismimpactportal.com/themes/thompson-okanagan/accommodation-information) and change the year selected

Ideally, test other chart with year / month / week/ quarter selectors to check if the other selectors are still working


## Related task:
https://vizzuality.atlassian.net/browse/TM-15