### PR TITLE
Unify colours by region 

### DIFF
--- a/frontend/constants/regions.ts
+++ b/frontend/constants/regions.ts
@@ -9,11 +9,11 @@ export const REGION_BBOX = {
 };
 
 export const REGION_COLORS = {
-  british_columbia: '#314057',
-  cariboo_chilcotin_coast: '#BB9075',
-  kootenay_rockies: '#405E62',
+  british_columbia: '#000000',
+  cariboo_chilcotin_coast: '#BA9077',
+  kootenay_rockies: '#1CB5A1',
   northern_british_columbia: '#A9B937',
-  thompson_okanagan: '#76ACA9',
-  vancouver_coast_and_mountains: '#063898',
-  vancouver_island: '#4F91CD',
+  thompson_okanagan: '#933633',
+  vancouver_coast_and_mountains: '#0C3B96',
+  vancouver_island: '#5292CB',
 };

--- a/frontend/constants/themes/tourism-employment.tsx
+++ b/frontend/constants/themes/tourism-employment.tsx
@@ -2,7 +2,7 @@ import uniq from 'lodash/uniq';
 import startCase from 'lodash/startCase';
 import groupBy from 'lodash/groupBy';
 import meanBy from 'lodash/meanBy';
-import { IndicatorValue, Region, ThemeFrontendDefinition } from 'types';
+import { IndicatorValue, ThemeFrontendDefinition } from 'types';
 
 import BoxImage from 'images/home/box-employment.png';
 
@@ -21,16 +21,6 @@ import { compactNumberTickFormatter, shortMonthName, thisYear, previousYear } fr
 import { defaultTooltip, bottomLegend } from 'constants/charts';
 import { getMapUrl } from 'hooks/map';
 import { getEconomicRegionsLayer } from 'hooks/layers';
-
-const ECONOMIC_REGION_COLORS = {
-  Cariboo: '#BB9075',
-  Kootenay: '#405E62',
-  'Thompson-Okanagan': '#76ACA9',
-  'Vancouver Island and Coast': '#4F91CD',
-  'British Columbia': '#314057',
-  Northeast: '#A9B937',
-  'North Coast and Nechako': '#00A572',
-};
 
 const theme: ThemeFrontendDefinition = {
   slug: 'tourism_employment',
@@ -75,19 +65,18 @@ const theme: ThemeFrontendDefinition = {
       },
       fetchWidgetProps(rawData: IndicatorValue[] = [], state: any): any {
         const filtered = filterBySelectedYear(rawData, state.year);
-        let chartData = mergeForChart({ data: filtered, mergeBy: 'date', labelKey: 'category_2', valueKey: 'value' });
-        const regions = uniq(rawData.map((x) => x.category_2));
+        let chartData = mergeForChart({ data: filtered, mergeBy: 'date', labelKey: 'region', valueKey: 'value' });
+
         let areas = [];
         if (state.year !== 'all_years') {
           chartData = expandToFullYear(chartData);
-          [chartData, areas] = getWithMinMaxAreas(chartData, rawData, 'category_2', ECONOMIC_REGION_COLORS);
+          [chartData, areas] = getWithMinMaxAreas(chartData, rawData, 'region', {}, 'region_slug');
         }
-
         return {
           type: 'charts/composed',
           data: chartData,
           controls: [{ type: 'select', side: 'right', name: 'year', options: getAvailableYearsOptions(rawData, true) }],
-          lines: regions.map((x) => ({ dataKey: x, color: ECONOMIC_REGION_COLORS[x] })),
+          lines: areas.map((x) => ({ dataKey: x.key, color: x.fill })),
           chartProps: {
             margin: {
               top: 35,
@@ -132,19 +121,19 @@ const theme: ThemeFrontendDefinition = {
       },
       fetchWidgetProps(rawData: IndicatorValue[] = [], state: any): any {
         const filtered = filterBySelectedYear(rawData, state.year);
-        let chartData = mergeForChart({ data: filtered, mergeBy: 'date', labelKey: 'category_2', valueKey: 'value' });
-        const regions = uniq(rawData.map((x) => x.category_2));
+        let chartData = mergeForChart({ data: filtered, mergeBy: 'date', labelKey: 'region', valueKey: 'value' });
+
         let areas = [];
         if (state.year !== 'all_years') chartData = expandToFullYear(chartData);
         if (state.year !== 'all_years' && state.selectedRegion.parent) {
-          [chartData, areas] = getWithMinMaxAreas(chartData, rawData, 'category_2', ECONOMIC_REGION_COLORS);
+          [chartData, areas] = getWithMinMaxAreas(chartData, rawData, 'region');
         }
 
         return {
           type: 'charts/composed',
           data: chartData,
           controls: [{ type: 'select', side: 'right', name: 'year', options: getAvailableYearsOptions(rawData, true) }],
-          lines: regions.map((x) => ({ dataKey: x, color: ECONOMIC_REGION_COLORS[x] })),
+          lines: areas.map((x) => ({ dataKey: x.key, color: x.fill })),
           areas,
           xAxis: {
             dataKey: 'date',


### PR DESCRIPTION
This PR updates the colours for regions and unify them for all indicators

## Testing instructions
Verify that all widgets that includes regions data have the same colours for regions
 
Exemple:
<img width="704" alt="Screenshot 2023-04-13 at 16 12 42" src="https://user-images.githubusercontent.com/48164343/231789504-bc331d28-b031-4969-b33f-63b00e82098a.png">

 
 ## Task
 https://vizzuality.atlassian.net/browse/TM-20