### PR TITLE
Fix all-regions line chart bug and change region colors

### DIFF
--- a/frontend/constants/regions.ts
+++ b/frontend/constants/regions.ts
@@ -9,11 +9,11 @@ export const REGION_BBOX = {
 };
 
 export const REGION_COLORS = {
-  british_columbia: '#000000',
+  british_columbia: '#314057',
   cariboo_chilcotin_coast: '#BA9077',
-  kootenay_rockies: '#1CB5A1',
+  kootenay_rockies: '#CCEFEA',
   northern_british_columbia: '#A9B937',
   thompson_okanagan: '#933633',
-  vancouver_coast_and_mountains: '#0C3B96',
+  vancouver_coast_and_mountains: '#1CB5A1',
   vancouver_island: '#5292CB',
 };

--- a/frontend/constants/themes/tourism-employment.tsx
+++ b/frontend/constants/themes/tourism-employment.tsx
@@ -66,7 +66,8 @@ const theme: ThemeFrontendDefinition = {
       fetchWidgetProps(rawData: IndicatorValue[] = [], state: any): any {
         const filtered = filterBySelectedYear(rawData, state.year);
         let chartData = mergeForChart({ data: filtered, mergeBy: 'date', labelKey: 'region', valueKey: 'value' });
-
+        const regions = uniq(rawData.map((x) => x.region));
+        const colorsByRegionName = getColorsByRegionName(rawData);
         let areas = [];
         if (state.year !== 'all_years') {
           chartData = expandToFullYear(chartData);
@@ -76,7 +77,7 @@ const theme: ThemeFrontendDefinition = {
           type: 'charts/composed',
           data: chartData,
           controls: [{ type: 'select', side: 'right', name: 'year', options: getAvailableYearsOptions(rawData, true) }],
-          lines: areas.map((x) => ({ dataKey: x.key, color: x.fill })),
+          lines: regions.map((x) => ({ dataKey: x, color: colorsByRegionName[x] })),
           chartProps: {
             margin: {
               top: 35,
@@ -122,6 +123,8 @@ const theme: ThemeFrontendDefinition = {
       fetchWidgetProps(rawData: IndicatorValue[] = [], state: any): any {
         const filtered = filterBySelectedYear(rawData, state.year);
         let chartData = mergeForChart({ data: filtered, mergeBy: 'date', labelKey: 'region', valueKey: 'value' });
+        const regions = uniq(rawData.map((x) => x.region));
+        const colorsByRegionName = getColorsByRegionName(rawData);
 
         let areas = [];
         if (state.year !== 'all_years') chartData = expandToFullYear(chartData);
@@ -133,7 +136,7 @@ const theme: ThemeFrontendDefinition = {
           type: 'charts/composed',
           data: chartData,
           controls: [{ type: 'select', side: 'right', name: 'year', options: getAvailableYearsOptions(rawData, true) }],
-          lines: areas.map((x) => ({ dataKey: x.key, color: x.fill })),
+          lines: regions.map((x) => ({ dataKey: x, color: colorsByRegionName[x] })),
           areas,
           xAxis: {
             dataKey: 'date',


### PR DESCRIPTION
This PR fixes a bug created on the previous PR. Some line charts didn't show data when in British Columbia regions or all-years was selected.

Bug:
<img width="768" alt="Screenshot 2023-04-14 at 12 20 10" src="https://user-images.githubusercontent.com/48164343/232018774-eca23bba-7381-4b9c-884e-2c5a908fc99e.png">

## Test instructions
Go to [tourism-employment](https://tota-git-client-featuretm-20-unify-color-dic-dee0f8-vizzuality1.vercel.app/themes/british-columbia/tourism-employment) and verify that widgets 2 and 3 have data for all the years options


 