### PR TITLE
Client/feature/tm-16 change chart type in british columbia employment

### DIFF
--- a/frontend/constants/themes/tourism-employment.tsx
+++ b/frontend/constants/themes/tourism-employment.tsx
@@ -65,29 +65,28 @@ const theme: ThemeFrontendDefinition = {
       },
       fetchWidgetProps(rawData: IndicatorValue[] = [], state: any): any {
         const filtered = filterBySelectedYear(rawData, state.year);
-        let chartData = mergeForChart({ data: filtered, mergeBy: 'date', labelKey: 'region', valueKey: 'value' });
         const regions = uniq(rawData.map((x) => x.region));
         const colorsByRegionName = getColorsByRegionName(rawData);
-        let areas = [];
-        if (state.year !== 'all_years') {
-          chartData = expandToFullYear(chartData);
-          [chartData, areas] = getWithMinMaxAreas(chartData, rawData, 'region', {}, 'region_slug');
-        }
+        const chartData = mergeForChart({ data: filtered, mergeBy: 'date', labelKey: 'region', valueKey: 'value' });
+
+        const isLineChart = state.year === 'all_years' && state.selectedRegion.slug === 'british_columbia';
+        const formatter = (date: string) => (state.year !== 'all_years' ? shortMonthName(date) : date);
+        const regionData = regions.map((x) => ({ dataKey: x, color: colorsByRegionName[x] }));
         return {
-          type: 'charts/composed',
+          type: isLineChart ? 'charts/line' : 'charts/bar',
           data: chartData,
           controls: [{ type: 'select', side: 'right', name: 'year', options: getAvailableYearsOptions(rawData, true) }],
-          lines: regions.map((x) => ({ dataKey: x, color: colorsByRegionName[x] })),
+          bars: regionData,
+          lines: regionData,
           chartProps: {
             margin: {
               top: 35,
               left: 10,
             },
           },
-          areas,
           xAxis: {
             dataKey: 'date',
-            tickFormatter: state.year !== 'all_years' && shortMonthName,
+            tickFormatter: formatter,
           },
           yAxis: {
             tickFormatter: compactNumberTickFormatter,
@@ -99,7 +98,8 @@ const theme: ThemeFrontendDefinition = {
           },
           tooltip: {
             ...defaultTooltip,
-            payloadFilter: (y) => !y.name.includes('min-max'),
+            cursor: false,
+            labelFormatter: formatter,
           },
         };
       },
@@ -122,37 +122,35 @@ const theme: ThemeFrontendDefinition = {
       },
       fetchWidgetProps(rawData: IndicatorValue[] = [], state: any): any {
         const filtered = filterBySelectedYear(rawData, state.year);
-        let chartData = mergeForChart({ data: filtered, mergeBy: 'date', labelKey: 'region', valueKey: 'value' });
         const regions = uniq(rawData.map((x) => x.region));
         const colorsByRegionName = getColorsByRegionName(rawData);
 
-        let areas = [];
-        if (state.year !== 'all_years') chartData = expandToFullYear(chartData);
-        if (state.year !== 'all_years' && state.selectedRegion.parent) {
-          [chartData, areas] = getWithMinMaxAreas(chartData, rawData, 'region');
-        }
+        const chartData = mergeForChart({ data: filtered, mergeBy: 'date', labelKey: 'region', valueKey: 'value' });
 
+        const isLineChart = state.year === 'all_years' && state.selectedRegion.slug === 'british_columbia';
+        const formatter = (date: string) => (state.year !== 'all_years' ? shortMonthName(date) : date);
+        const regionData = regions.map((x) => ({ dataKey: x, color: colorsByRegionName[x] }));
         return {
-          type: 'charts/composed',
+          type: isLineChart ? 'charts/line' : 'charts/bar',
           data: chartData,
           controls: [{ type: 'select', side: 'right', name: 'year', options: getAvailableYearsOptions(rawData, true) }],
-          lines: regions.map((x) => ({ dataKey: x, color: colorsByRegionName[x] })),
-          areas,
+          bars: regionData,
+          lines: regionData,
           xAxis: {
             dataKey: 'date',
-            tickFormatter: state.year !== 'all_years' && shortMonthName,
+            tickFormatter: formatter,
           },
           yAxis: {
             tickFormatter: (val) => `${val}%`,
           },
           legend: {
             ...bottomLegend,
-            payloadFilter: (y) => !y.value.includes('min-max'),
           },
           tooltip: {
             ...defaultTooltip,
-            valueFormatter: (value) => `${value.toFixed(2)}%`,
-            payloadFilter: (y) => !y.name.includes('min-max'),
+            cursor: false,
+            valueFormatter: (value: number) => `${value.toFixed(2)}%`,
+            labelFormatter: formatter,
           },
         };
       },
@@ -175,35 +173,34 @@ const theme: ThemeFrontendDefinition = {
       },
       fetchWidgetProps(rawData: IndicatorValue[] = [], state: any): any {
         const filtered = filterBySelectedYear(rawData, state.year);
-        let chartData = mergeForChart({ data: filtered, mergeBy: 'date', labelKey: 'region', valueKey: 'value' });
+        const chartData = mergeForChart({ data: filtered, mergeBy: 'date', labelKey: 'region', valueKey: 'value' });
         const regions = uniq(rawData.map((x) => x.region));
         const colorsByRegionName = getColorsByRegionName(rawData);
-        let areas = [];
-        if (state.year !== 'all_years') chartData = expandToFullYear(chartData);
-        if (state.year !== 'all_years' && state.selectedRegion.parent) {
-          [chartData, areas] = getWithMinMaxAreas(chartData, rawData, 'region', colorsByRegionName);
-        }
 
+        const isLineChart = state.year === 'all_years' && state.selectedRegion.slug === 'british_columbia';
+
+        const formatter = (date: string) => (state.year !== 'all_years' ? shortMonthName(date) : date);
+        const regionData = regions.map((x) => ({ dataKey: x, color: colorsByRegionName[x] }));
         return {
-          type: 'charts/composed',
+          type: isLineChart ? 'charts/line' : 'charts/bar',
           data: chartData,
           controls: [{ type: 'select', side: 'right', name: 'year', options: getAvailableYearsOptions(rawData, true) }],
-          lines: regions.map((x) => ({ dataKey: x, color: colorsByRegionName[x] })),
-          areas,
+          bars: regionData,
+          lines: regionData,
           xAxis: {
             dataKey: 'date',
-            tickFormatter: state.year !== 'all_years' && shortMonthName,
+            tickFormatter: formatter,
           },
           yAxis: {
             tickFormatter: compactNumberTickFormatter,
           },
           legend: {
             ...bottomLegend,
-            payloadFilter: (y) => !y.value.includes('min-max'),
           },
           tooltip: {
             ...defaultTooltip,
-            payloadFilter: (y) => !y.name.includes('min-max'),
+            cursor: false,
+            labelFormatter: formatter,
           },
         };
       },


### PR DESCRIPTION
This task changes 3 widgets chart types from 'line' to 'bar'
The exception is when the region 'British Columbia' is selected for 'all-years'  (decision made with data and PM)

## Test instructions

- Go to [ANY_REGION/tourism-employment](https://tota-git-client-featuretm-16-fe-change-chart-59b123-vizzuality1.vercel.app/themes/northern-british-columbia/tourism-employment) 
- Select any region other than 'British Columbia' and be sure that the widgets 2, 3 and 4 are grouped bar charts.
- Change the region to 'British Columbia' and change the selected years. The widgets should be a **line** charts ONLY for 'all-years'

## Task:
https://vizzuality.atlassian.net/browse/TM-16